### PR TITLE
Fix component add rollback

### DIFF
--- a/src/dove/core/system.py
+++ b/src/dove/core/system.py
@@ -163,7 +163,11 @@ class System:
             If the component validation fails (via verify method).
         """
         self.components.append(comp)
-        self.verify()
+        try:
+            self.verify()
+        except Exception:
+            self.components.pop()
+            raise
         self.comp_map[comp.name] = comp
         return self
 

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -47,6 +47,8 @@ def test_adding_duplicate_component_name_raises():
     sys.add_component(c1)
     with pytest.raises(ValueError):
         sys.add_component(c2)
+    assert sys.components == [c1]
+    assert sys.comp_map["c"] is c1
 
 
 # def test_remove_component_and_resource_cleanup():


### PR DESCRIPTION
## Summary
- ensure failed component adds restore the system state
- test that System.add_component leaves no trace of failed addition

## Testing
- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run mypy src/dove/core`
- `uv run codespell --quiet-level 2 -L hist`
- `uv run pytest tests/unit/test_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6841fa3cf45c8333b5ac6499eb400646